### PR TITLE
BD-938:Compliance Issues in opensync-vendor-rdk-rpi

### DIFF
--- a/ovsdb/inet.json.sh
+++ b/ovsdb/inet.json.sh
@@ -1,3 +1,21 @@
+########################################################################
+# If not stated otherwise in this file or this component's LICENSE
+# file the following copyright and licenses apply:
+#
+# Copyright [2020] [RDK Management]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+########################################################################
 if [ "$CONFIG_RDK_EXTENDER" == "y" ]; then
     # do nothing if not set
     echo '["Open_vSwitch"]'


### PR DESCRIPTION
Reason for change: Updated missed header change.
Test Procedure: Jenkin build should pass after License header changes for RDK for listed repos
Risks: None
